### PR TITLE
Calculate mobility per piece instead of per piece type

### DIFF
--- a/search_mgr.cpp
+++ b/search_mgr.cpp
@@ -899,7 +899,7 @@ namespace Zagreus {
         uint64_t whiteQueenAttacks = 0;
 
         uint64_t blackPawnAttacks = bitboard.calculatePawnAttacks(blackPawnBB, PieceColor::BLACK);
-        uint64_t blackKnightAttacks = calculateKnightAttacks(blackKnightBB);
+        uint64_t blackKnightAttacks = 0;
         uint64_t blackBishopAttacks = 0;
         uint64_t blackRookAttacks = 0;
         uint64_t blackQueenAttacks = 0;

--- a/search_mgr.cpp
+++ b/search_mgr.cpp
@@ -911,7 +911,7 @@ namespace Zagreus {
             uint64_t index = bitscanForward(whiteKnightBB);
 
             uint64_t attacks = bitboard.getKnightAttacks(index);
-            whiteKnightBB |= attacks;
+            whiteKnightAttacks |= attacks;
             attacksFrom[index] = attacks;
 
             whiteKnightBB &= ~(1ULL << index);
@@ -921,7 +921,7 @@ namespace Zagreus {
             uint64_t index = bitscanForward(blackKnightBB);
 
             uint64_t attacks = bitboard.getKnightAttacks(index);
-            blackKnightBB |= attacks;
+            blackKnightAttacks |= attacks;
             attacksFrom[index] = attacks;
 
             blackKnightBB &= ~(1ULL << index);

--- a/search_mgr.cpp
+++ b/search_mgr.cpp
@@ -764,17 +764,6 @@ namespace Zagreus {
                     break;
             }
 
-            evalContext.whiteMidgameScore -= popcnt(attacks & evalContext.blackPawnAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_PAWN) / 100));
-            evalContext.whiteEndgameScore -= popcnt(attacks & evalContext.blackPawnAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_PAWN) / 100));
-            evalContext.whiteMidgameScore -= popcnt(attacks & evalContext.blackKnightAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_KNIGHT) / 100));
-            evalContext.whiteEndgameScore -= popcnt(attacks & evalContext.blackKnightAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_KNIGHT) / 100));
-            evalContext.whiteMidgameScore -= popcnt(attacks & evalContext.blackBishopAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_BISHOP) / 100));
-            evalContext.whiteEndgameScore -= popcnt(attacks & evalContext.blackBishopAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_BISHOP) / 100));
-            evalContext.whiteMidgameScore -= popcnt(attacks & evalContext.blackRookAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_ROOK) / 100));
-            evalContext.whiteEndgameScore -= popcnt(attacks & evalContext.blackRookAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_ROOK) / 100));
-            evalContext.whiteMidgameScore -= popcnt(attacks & evalContext.blackQueenAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_QUEEN) / 100));
-            evalContext.whiteEndgameScore -= popcnt(attacks & evalContext.blackQueenAttacks) * (11 - (bitboard.getPieceWeight(PieceType::BLACK_QUEEN) / 100));
-
             ownPiecesBBLoop &= ~(1ULL << index);
         }
     }
@@ -816,27 +805,6 @@ namespace Zagreus {
                     evalContext.blackEndgameScore += popcnt(attacks & ~ownPiecesBB) * 8;
                     break;
             }
-
-            evalContext.blackMidgameScore -= popcnt(attacks & evalContext.whitePawnAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_PAWN) / 100));
-            evalContext.blackEndgameScore -= popcnt(attacks & evalContext.whitePawnAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_PAWN) / 100));
-            evalContext.blackMidgameScore -= popcnt(attacks & evalContext.whiteKnightAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_KNIGHT) / 100));
-            evalContext.blackEndgameScore -= popcnt(attacks & evalContext.whiteKnightAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_KNIGHT) / 100));
-            evalContext.blackMidgameScore -= popcnt(attacks & evalContext.whiteBishopAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_BISHOP) / 100));
-            evalContext.blackEndgameScore -= popcnt(attacks & evalContext.whiteBishopAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_BISHOP) / 100));
-            evalContext.blackMidgameScore -= popcnt(attacks & evalContext.whiteRookAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_ROOK) / 100));
-            evalContext.blackEndgameScore -= popcnt(attacks & evalContext.whiteRookAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_ROOK) / 100));
-            evalContext.blackMidgameScore -= popcnt(attacks & evalContext.whiteQueenAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_QUEEN) / 100));
-            evalContext.blackEndgameScore -= popcnt(attacks & evalContext.whiteQueenAttacks) *
-                                             (11 - (bitboard.getPieceWeight(PieceType::WHITE_QUEEN) / 100));
 
             ownPiecesBBLoop &= ~(1ULL << index);
         }

--- a/search_mgr.h
+++ b/search_mgr.h
@@ -42,6 +42,7 @@ namespace Zagreus {
         uint64_t blackRookAttacks = 0;
         uint64_t blackQueenAttacks = 0;
         uint64_t blackCombinedAttacks = 0;
+        uint64_t attacksFrom[64] = { 0ULL };
     };
 
     class SearchManager {


### PR DESCRIPTION
Idk why I did it the other way, doesn't make much sense...

ELO   | 4.33 +- 7.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=64MB
LLR   | 0.53 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 6024 W: 2400 L: 2325 D: 1299