### PR TITLE
Increase penalty for pawn distance from promotion square in the endgame

### DIFF
--- a/search_mgr.cpp
+++ b/search_mgr.cpp
@@ -844,9 +844,9 @@ namespace Zagreus {
             uint64_t tilesBetween = bitboard.getTilesBetween(index, promotionSquare);
 
             if (color == PieceColor::WHITE) {
-                evalContext.whiteEndgameScore -= popcnt(tilesBetween) * 10;
+                evalContext.whiteEndgameScore -= popcnt(tilesBetween) * 20;
             } else {
-                evalContext.blackEndgameScore -= popcnt(tilesBetween) * 10;
+                evalContext.blackEndgameScore -= popcnt(tilesBetween) * 20;
             }
 
             pawnBB &= ~(1ULL << index);


### PR DESCRIPTION
ELO   | 35.15 +- 11.23 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 2896 W: 1274 L: 982 D: 640

Bench: 4993968