### PR TITLE
Better move ordering

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -152,6 +152,7 @@ namespace Zagreus {
         undoStack[ply].moveType = MoveType::REGULAR;
         undoStack[ply].zobristHash = zobristHash;
         undoStack[ply].kingInCheck = kingInCheck;
+        undoStack[ply].previousMove = previousMove;
         halfMoveClock += 1;
 
         if (capturedPiece != PieceType::EMPTY) {
@@ -278,6 +279,7 @@ namespace Zagreus {
         zobristHash ^= zobristConstants[ZOBRIST_COLOR_INDEX];
         ply += 1;
         moveHistory[ply] = getZobristHash();
+        previousMove = move;
     }
 
     void Bitboard::unmakeMove(Move &move) {
@@ -329,10 +331,15 @@ namespace Zagreus {
         movingColor = getOppositeColor(movingColor);
         zobristHash = undoData.zobristHash;
         kingInCheck = undoData.kingInCheck;
+        previousMove = undoData.previousMove;
 
         if (movingColor == PieceColor::BLACK) {
             fullmoveClock -= 1;
         }
+    }
+
+    const Move &Bitboard::getPreviousMove() const {
+        return previousMove;
     }
 
     uint64_t Bitboard::getZobristForMove(Move &move) {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -56,6 +56,8 @@ namespace Zagreus {
         UndoData undoStack[MAX_PLY]{};
         uint64_t moveHistory[MAX_PLY]{};
         Line previousPvLine{};
+
+        Move previousMove{};
     public:
         uint64_t zobristConstants[ZOBRIST_CONSTANT_SIZE]{};
 
@@ -354,6 +356,8 @@ namespace Zagreus {
         }
 
         uint64_t getTilesBetween(int8_t from, int8_t to);
+
+        const Move &getPreviousMove() const;
     };
 }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -57,6 +57,8 @@ static constexpr uint64_t WHITE_QUEEN_SIDE_BETWEEN = 0xEULL;
 static constexpr uint64_t BLACK_KING_SIDE_BETWEEN = 0x6000000000000000ULL;
 static constexpr uint64_t BLACK_QUEEN_SIDE_BETWEEN = 0xE00000000000000ULL;
 
+static constexpr int NO_CAPTURE_SCORE = -1;
+
 static constexpr int MVVLVA_TABLE[12][12] = {
         {105, 205, 305, 405, 505, 605,  105, 205, 305, 405, 505, 605},
         {104, 204, 304, 404, 504, 604,  104, 204, 304, 404, 504, 604},

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -47,18 +47,23 @@ namespace Zagreus {
             return 10000 + move.captureScore;
         }
 
-        /*uint32_t aMoveCode = encodeMove(move);
-        if (tt->killerMoves[0][move.ply] == aMoveCode) {
+        uint32_t aMoveCode = encodeMove(move);
+        if (tt->killerMoves[0][bitboard.getPly()] == aMoveCode) {
             return 5000;
         }
 
-        if (tt->killerMoves[1][move.ply] == aMoveCode) {
+        if (tt->killerMoves[1][bitboard.getPly()] == aMoveCode) {
             return 4000;
         }
 
+        if (tt->killerMoves[1][bitboard.getPly()] == aMoveCode) {
+            return 3000;
+        }
+
+        /*
         if (tt->counterMoves[bitboard.getPreviousMoveFrom()][bitboard.getPreviousMoveTo()] ==
             aMoveCode) {
-            return 3000;
+            return 2000;
         }*/
 
         if (move.captureScore < -1) {
@@ -151,7 +156,7 @@ namespace Zagreus {
                 int8_t genIndex = bitscanForward(genBB);
                 genBB = _blsr_u64(genBB);
                 PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-                int captureScore = -1;
+                int captureScore = NO_CAPTURE_SCORE;
 
                 if (color == PieceColor::WHITE) {
                     if (capturedPiece != PieceType::EMPTY) {
@@ -214,7 +219,7 @@ namespace Zagreus {
                 int8_t genIndex = bitscanForward(genBB);
                 genBB = _blsr_u64(genBB);
                 PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-                int captureScore = -1;
+                int captureScore = NO_CAPTURE_SCORE;
 
                 if (color == PieceColor::WHITE) {
                     if (capturedPiece != PieceType::EMPTY) {
@@ -263,7 +268,7 @@ namespace Zagreus {
                 int8_t genIndex = bitscanForward(genBB);
                 genBB = _blsr_u64(genBB);
                 PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-                int captureScore = -1;
+                int captureScore = NO_CAPTURE_SCORE;
 
                 if (color == PieceColor::WHITE) {
                     if (capturedPiece != PieceType::EMPTY) {
@@ -312,7 +317,7 @@ namespace Zagreus {
                 int8_t genIndex = bitscanForward(genBB);
                 genBB = _blsr_u64(genBB);
                 PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-                int captureScore = -1;
+                int captureScore = NO_CAPTURE_SCORE;
 
                 if (color == PieceColor::WHITE) {
                     if (capturedPiece != PieceType::EMPTY) {
@@ -361,7 +366,7 @@ namespace Zagreus {
                 int8_t genIndex = bitscanForward(genBB);
                 genBB = _blsr_u64(genBB);
                 PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-                int captureScore = -1;
+                int captureScore = NO_CAPTURE_SCORE;
 
                 if (color == PieceColor::WHITE) {
                     if (capturedPiece != PieceType::EMPTY) {
@@ -411,7 +416,7 @@ namespace Zagreus {
             int8_t genIndex = bitscanForward(genBB);
             genBB = _blsr_u64(genBB);
             PieceType capturedPiece = bitboard.getPieceOnSquare(genIndex);
-            int captureScore = -1;
+            int captureScore = NO_CAPTURE_SCORE;
 
             if (color == PieceColor::WHITE) {
                 if (capturedPiece != PieceType::EMPTY) {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -47,24 +47,23 @@ namespace Zagreus {
             return 10000 + move.captureScore;
         }
 
-        uint32_t aMoveCode = encodeMove(move);
-        if (tt->killerMoves[0][bitboard.getPly()] == aMoveCode) {
+        uint32_t moveCode = encodeMove(move);
+        if (tt->killerMoves[0][bitboard.getPly()] == moveCode) {
             return 5000;
         }
 
-        if (tt->killerMoves[1][bitboard.getPly()] == aMoveCode) {
+        if (tt->killerMoves[1][bitboard.getPly()] == moveCode) {
             return 4000;
         }
 
-        if (tt->killerMoves[1][bitboard.getPly()] == aMoveCode) {
+        if (tt->killerMoves[1][bitboard.getPly()] == moveCode) {
             return 3000;
         }
 
-        /*
-        if (tt->counterMoves[bitboard.getPreviousMoveFrom()][bitboard.getPreviousMoveTo()] ==
-            aMoveCode) {
+        Move previousMove = bitboard.getPreviousMove();
+        if (tt->counterMoves[previousMove.from][previousMove.to] == moveCode) {
             return 2000;
-        }*/
+        }
 
         if (move.captureScore < -1) {
             return move.captureScore - 5000;

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -70,8 +70,7 @@ namespace Zagreus {
             return move.captureScore - 5000;
         }
 
-//        return tt->historyMoves[move.pieceType][move.to];
-        return 0;
+        return tt->historyMoves[move.piece][move.to];
     }
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -206,6 +206,12 @@ namespace Zagreus {
 
             if (score > alpha) {
                 if (score >= beta) {
+                    if (move.captureScore == NO_CAPTURE_SCORE) {
+                        TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
+                        TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
+                        TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                    }
+
                     TranspositionTable::getTT()->addPosition(board.getZobristHash(), depth, beta, NodeType::FAIL_HIGH_NODE);
                     return score;
                 }
@@ -265,6 +271,12 @@ namespace Zagreus {
 
             if (score > alpha) {
                 if (score >= beta) {
+                    if (move.captureScore == NO_CAPTURE_SCORE) {
+                        TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
+                        TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
+                        TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                    }
+
                     TranspositionTable::getTT()->addPosition(board.getZobristHash(), depth, beta, NodeType::FAIL_HIGH_NODE);
                     return beta;
                 }
@@ -328,8 +340,7 @@ namespace Zagreus {
                 return beta;
             }
 
-            // -1 means it's not a capture
-            if (move.captureScore <= -1) {
+            if (move.captureScore <= NO_CAPTURE_SCORE) {
                 continue;
             }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -212,6 +212,7 @@ namespace Zagreus {
                         TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                        TranspositionTable::getTT()->counterMoves[previousMove.from][previousMove.to] = encodeMove(move);
                         TranspositionTable::getTT()->historyMoves[move.piece][move.to] += depth * depth;
                     }
 
@@ -278,6 +279,7 @@ namespace Zagreus {
                         TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                        TranspositionTable::getTT()->counterMoves[previousMove.from][previousMove.to] = encodeMove(move);
                         TranspositionTable::getTT()->historyMoves[move.piece][move.to] += depth * depth;
                     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -42,6 +42,8 @@ namespace Zagreus {
         std::chrono::time_point<std::chrono::high_resolution_clock> endTime = getEndTime(params, board, engine, board.getMovingColor());
         int depth = 0;
 
+        TranspositionTable::getTT()->ageHistoryTable();
+
         Line iterationPvLine = {};
         while (!engine.stopRequested() && std::chrono::high_resolution_clock::now() - startTime < (endTime - startTime) * 0.7) {
             depth += 1;
@@ -210,6 +212,7 @@ namespace Zagreus {
                         TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                        TranspositionTable::getTT()->historyMoves[move.piece][move.to] += depth * depth;
                     }
 
                     TranspositionTable::getTT()->addPosition(board.getZobristHash(), depth, beta, NodeType::FAIL_HIGH_NODE);
@@ -275,6 +278,7 @@ namespace Zagreus {
                         TranspositionTable::getTT()->killerMoves[2][board.getPly()] = TranspositionTable::getTT()->killerMoves[1][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[1][board.getPly()] = TranspositionTable::getTT()->killerMoves[0][board.getPly()];
                         TranspositionTable::getTT()->killerMoves[0][board.getPly()] = encodeMove(move);
+                        TranspositionTable::getTT()->historyMoves[move.piece][move.to] += depth * depth;
                     }
 
                     TranspositionTable::getTT()->addPosition(board.getZobristHash(), depth, beta, NodeType::FAIL_HIGH_NODE);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -87,4 +87,12 @@ namespace Zagreus {
     TranspositionTable* TranspositionTable::TranspositionTable::getTT() {
         return instance;
     }
+
+    void TranspositionTable::ageHistoryTable() {
+        for (int i = 0; i < 12; i++) {
+            for (int j = 0; j < 64; j++) {
+                historyMoves[i][j] /= 8;
+            }
+        }
+    }
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -50,7 +50,7 @@ namespace Zagreus {
 
         TranspositionTable() {
             for (int i = 0; i < 3; i++) {
-                killerMoves[i] = new uint32_t[128]{};
+                killerMoves[i] = new uint32_t[MAX_PLY]{};
             }
 
             for (int i = 0; i < 12; i++) {

--- a/src/tt.h
+++ b/src/tt.h
@@ -42,7 +42,6 @@ namespace Zagreus {
 
         TTEntry* transpositionTable = new TTEntry[1]{};
         uint32_t** killerMoves = new uint32_t*[3]{};
-        // TODO: make 1d
         uint32_t** historyMoves = new uint32_t*[12]{};
         uint32_t** counterMoves = new uint32_t*[64]{};
 
@@ -95,5 +94,7 @@ namespace Zagreus {
         int getScore(uint64_t zobristHash, int depth, int alpha, int beta);
 
         TTEntry getEntry(uint64_t zobristHash);
+
+        void ageHistoryTable();
     };
 }

--- a/src/types.h
+++ b/src/types.h
@@ -78,6 +78,7 @@ namespace Zagreus {
         MoveType moveType = MoveType::REGULAR;
         uint64_t zobristHash = 0ULL;
         uint8_t kingInCheck = 0b00001100;
+        Move previousMove{};
     };
 
     struct MoveList {

--- a/src/types.h
+++ b/src/types.h
@@ -59,7 +59,7 @@ namespace Zagreus {
         int8_t from = 0;
         int8_t to = 0;
         PieceType piece = PieceType::EMPTY;
-        int captureScore = -1;
+        int captureScore = NO_CAPTURE_SCORE;
         PieceType promotionPiece = PieceType::EMPTY;
         int score = 0;
     };
@@ -93,14 +93,14 @@ namespace Zagreus {
     };
 
     enum Direction {
-        NORTH = 8,
-        SOUTH = -8,
-        EAST = 1,
-        WEST = -1,
-        NORTH_EAST = 9,
-        NORTH_WEST = 7,
-        SOUTH_EAST = -7,
-        SOUTH_WEST = -9
+        NORTH,
+        SOUTH,
+        EAST,
+        WEST,
+        NORTH_EAST,
+        NORTH_WEST,
+        SOUTH_EAST,
+        SOUTH_WEST
     };
 
     struct Line {


### PR DESCRIPTION
ELO   | 4.15 +- 5.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=64MB
LLR   | 1.07 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 14472 W: 6480 L: 6307 D: 1685