### PR TITLE
 Fix outpost evaluation and pawn attacks not being taken into account during evaluation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tuner-data/tuner.epd filter=lfs diff=lfs merge=lfs -text

--- a/src/features.cpp
+++ b/src/features.cpp
@@ -106,7 +106,17 @@ namespace Zagreus {
 
     void printEvalValues() {
         for (int i = 0; i < getEvalFeatureSize(); i++) {
-            std::cout << evalFeatureNames[i] << ": " << evalValues[i] << std::endl;
+            std::cout << evalFeatureNames[i] << ": " << evalValues[i];
+
+            if (evalValues[i] == baseEvalValues[i]) {
+                std::cout << " (unchanged)";
+            } else if (evalValues[i] > 0 && baseEvalValues[i] < 0) {
+                std::cout << " (Positive to negative)";
+            } else if (evalValues[i] < 0 && baseEvalValues[i] > 0) {
+                std::cout << " (Negative to positive)";
+            }
+
+            std::cout << std::endl;
         }
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1053,7 +1053,7 @@ namespace Zagreus {
                     if (bitboard.isSemiOpenFile<PieceColor::WHITE>(i)) {
                         evalContext.blackMidgameScore += getEvalValue(MIDGAME_PAWN_SEMI_OPEN_FILE);
                         evalContext.blackEndgameScore += getEvalValue(ENDGAME_PAWN_SEMI_OPEN_FILE);
-                    }
+                   }
                 }
             }
         }


### PR DESCRIPTION
ELO   | 9.94 +- 5.72 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 12872 W: 6042 L: 5674 D: 1156

Bench: 13336455