### PR TITLE
Simplify versioning scheme, no more "patch" versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 20)
 project(Zagreus)
-set(ZAGREUS_VERSION "v2.3.1")
+set(ZAGREUS_VERSION_MAJOR "2")
+set(ZAGREUS_VERSION_MINOR "4")
 
 # Default values
 set(BUILD_FLAGS "")
@@ -184,14 +185,15 @@ if (APPEND_VERSION)
 
         # Append the branch and commit hash to the executable suffix
         set(CMAKE_EXECUTABLE_SUFFIX "-dev-${GIT_BRANCH}-${GIT_COMMIT_HASH}${CMAKE_EXECUTABLE_SUFFIX}")
-        set(ZAGREUS_VERSION "dev-${GIT_BRANCH}-${GIT_COMMIT_HASH}")
+        set(ZAGREUS_VERSION_MAJOR "dev")
+        set(ZAGREUS_VERSION_MINOR "${GIT_BRANCH}-${GIT_COMMIT_HASH}")
     else()
         if (ENABLE_MARCH)
             set(CMAKE_EXECUTABLE_SUFFIX "-${MARCH_VALUE}${CMAKE_EXECUTABLE_SUFFIX}")
         endif()
 
         set(CMAKE_EXECUTABLE_SUFFIX "-${CMAKE_SYSTEM_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
-        set(CMAKE_EXECUTABLE_SUFFIX "-${ZAGREUS_VERSION}${CMAKE_EXECUTABLE_SUFFIX}")
+        set(CMAKE_EXECUTABLE_SUFFIX "-v${ZAGREUS_VERSION_MAJOR}.${ZAGREUS_VERSION_MINOR}${CMAKE_EXECUTABLE_SUFFIX}")
     endif()
 endif()
 
@@ -262,4 +264,5 @@ file(GLOB inc_senjo "senjo/*.h" "senjo/*.cpp")
 
 add_executable(Zagreus src/main.cpp ${inc_senjo} ${inc_zagreus})
 
-target_compile_definitions(Zagreus PRIVATE ZAGREUS_VERSION="${ZAGREUS_VERSION}")
+target_compile_definitions(Zagreus PRIVATE ZAGREUS_VERSION_MAJOR="${ZAGREUS_VERSION_MAJOR}")
+target_compile_definitions(Zagreus PRIVATE ZAGREUS_VERSION_MINOR="${ZAGREUS_VERSION_MINOR}")

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -84,8 +84,15 @@ namespace Zagreus {
         return "Zagreus";
     }
 
+    std::string majorVersion = ZAGREUS_VERSION_MAJOR;
+    std::string minorVersion = ZAGREUS_VERSION_MINOR;
+
     std::string ZagreusEngine::getEngineVersion() {
-        return ZAGREUS_VERSION;
+        if (majorVersion != "dev") {
+            return "v" + majorVersion + "." + minorVersion;
+        } else {
+            return majorVersion + "-" + minorVersion;
+        }
     }
 
     std::string ZagreusEngine::getAuthorName() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,15 @@ int main(int argc , char *argv[]) {
     senjo::Output(senjo::Output::NoPrefix) << "";
 
     // ZAGREUS_VERSION preprocessor macro for version number
-    senjo::Output(senjo::Output::NoPrefix) << "Zagreus UCI chess engine version " << ZAGREUS_VERSION << " by Danny Jelsma (https://github.com/Dannyj1/Zagreus)";
+    std::string majorVersion = ZAGREUS_VERSION_MAJOR;
+    std::string minorVersion = ZAGREUS_VERSION_MINOR;
+    std::string versionString = "v" + majorVersion + "." + minorVersion;
+
+    if (majorVersion == "dev") {
+        versionString = majorVersion + "-" + minorVersion;
+    }
+
+    senjo::Output(senjo::Output::NoPrefix) << "Zagreus UCI chess engine " << versionString << " by Danny Jelsma (https://github.com/Dannyj1/Zagreus)";
 
     if (argc >= 2) {
         if (strcmp(argv[1], "bench") == 0) {


### PR DESCRIPTION
Instead of having versions like 2.3.1, I will now use versions like 2.3 and 3.0 indicating "MAJOR.MINOR". The third number has been removed.

Bench: 10569277