### PR TITLE
Fixed counter move history ordering

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -23,6 +23,7 @@
 #include <x86intrin.h>
 
 #include <cassert>
+#include <iostream>
 
 #include "bitboard.h"
 #include "tt.h"
@@ -44,32 +45,32 @@ int scoreMove(int ply, uint32_t pvMoveCode, const uint32_t* previousPvMoveCodes,
               Move& previousMove, uint32_t moveCode, uint32_t bestMoveCode,
               TranspositionTable* tt) {
     if (moveCode == pvMoveCode) {
-        return 50000;
+        return 500000;
     }
 
     if (moveCode == bestMoveCode) {
-        return 25000;
+        return 250000;
     }
 
     if (move->captureScore >= 0) {
-        return 10000 + move->captureScore;
+        return 100000 + move->captureScore;
     }
 
     if (tt->killerMoves[0][ply] == moveCode) {
-        return 5000;
+        return 50000;
     }
 
     if (tt->killerMoves[1][ply] == moveCode) {
-        return 4000;
+        return 40000;
     }
 
     if (tt->killerMoves[2][ply] == moveCode) {
-        return 3000;
+        return 30000;
     }
 
-    if (previousMove.from != NO_SQUARE && previousMove.to != NO_SQUARE
-        && tt->counterMoves[previousMove.from][previousMove.to] == moveCode) {
-        return 2000;
+    if (previousMove.piece != EMPTY && previousMove.to != NO_SQUARE
+        && tt->counterMoves[previousMove.piece][previousMove.to] == moveCode) {
+        return 20000;
     }
 
     // No capture score is -1, so we need to use < -1

--- a/src/tt.h
+++ b/src/tt.h
@@ -47,8 +47,8 @@ class TranspositionTable {
 public:
     TTEntry* transpositionTable = new TTEntry[1]{};
     uint32_t** killerMoves = new uint32_t*[3]{};
-    uint32_t** historyMoves = new uint32_t*[12]{};
-    uint32_t** counterMoves = new uint32_t*[64]{};
+    uint32_t** historyMoves = new uint32_t*[PIECE_TYPES]{};
+    uint32_t** counterMoves = new uint32_t*[PIECE_TYPES]{};
 
     uint64_t hashSize = 0;
 
@@ -57,11 +57,11 @@ public:
             killerMoves[i] = new uint32_t[MAX_PLY]{};
         }
 
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < PIECE_TYPES; i++) {
             historyMoves[i] = new uint32_t[64]{};
         }
 
-        for (int i = 0; i < 64; i++) {
+        for (int i = 0; i < PIECE_TYPES; i++) {
             counterMoves[i] = new uint32_t[64]{};
         }
     }
@@ -77,7 +77,7 @@ public:
             delete[] historyMoves[i];
         }
 
-        for (int i = 0; i < 64; i++) {
+        for (int i = 0; i < PIECE_TYPES; i++) {
             delete[] counterMoves[i];
         }
 


### PR DESCRIPTION
Elo   | 8.29 +- 6.58 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 1.27 (-2.94, 2.94) [0.50, 2.50]
Games | N: 8258 W: 3289 L: 3092 D: 1877
Penta | [389, 681, 1895, 672, 492]

Bench: 10679926